### PR TITLE
fix: verify Exodus migration TLS certificates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) Mhike, 2022-2025
+   Copyright (c) Mhike, 2022-2026
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: Exodus
-Copyright (c) Mhike, 2022-2025
+Copyright (c) Mhike, 2022-2026

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Exodus
 
-Publisher: Mhike \
-Connector Version: 1.0.1 \
-Product Vendor: Mhike \
-Product Name: Exodus \
+Publisher: Mhike <br>
+Connector Version: 1.0.1 <br>
+Product Vendor: Mhike <br>
+Product Name: Exodus <br>
 Minimum Product Version: 4.9.0
 
 The Exodus app manages various operations used in migrating content from dev to prod
@@ -23,18 +23,19 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 **target_api_token** | required | password | API token for target SOAR host |
 **target_repo_id** | required | string | Prod repository ID on target SOAR host |
 **debug** | optional | boolean | Print debugging statements to log |
+**verify_server_cert** | optional | boolean | Verify TLS certificates for source and target SOAR hosts. Disable only temporarily for troubleshooting. |
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied credentials \
-[add approval](#action-add-approval) - Add approval artifact to container \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied credentials <br>
+[add approval](#action-add-approval) - Add approval artifact to container <br>
 [on poll](#action-on-poll) - Execute migration options
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied credentials
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -49,7 +50,7 @@ No Output
 
 Add approval artifact to container
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 Add a specifically formatted artifact that is required for the approval process for exodus containers.
@@ -73,7 +74,7 @@ summary.total_objects_successful | numeric | | |
 
 Execute migration options
 
-Type: **ingest** \
+Type: **ingest** <br>
 Read only: **False**
 
 Create required exodus containers and migrate approved content to production system.
@@ -90,7 +91,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Splunk Inc.
+# Copyright (c) 2025-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/exodus.json
+++ b/exodus.json
@@ -14,8 +14,8 @@
     "min_phantom_version": "4.9.0",
     "logo": "logo_exodus.svg",
     "logo_dark": "logo_exodus_dark.svg",
-    "license": "Copyright (c) Mhike, 2022-2025",
-    "python_version": "3",
+    "license": "Copyright (c) Mhike, 2022-2026",
+    "python_version": "3.9, 3.13",
     "contributors": [
         {
             "name": "Mhike"
@@ -164,10 +164,10 @@
             "versions": "EQ(*)"
         }
     ],
-    "directory": "exodus_7fbd6b83-a9c6-4949-8e09-34bf2c39694d",
-    "version": 1,
-    "appname": "-",
-    "executable": "spawn3",
-    "disabled": false,
-    "custom_made": true
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/exodus.json
+++ b/exodus.json
@@ -93,6 +93,12 @@
             "order": 8,
             "name": "debug",
             "id": 8
+        },
+        "verify_server_cert": {
+            "description": "Verify TLS certificates for source and target SOAR hosts. Disable only temporarily for troubleshooting.",
+            "data_type": "boolean",
+            "default": true,
+            "order": 9
         }
     },
     "actions": [

--- a/exodus_connector.py
+++ b/exodus_connector.py
@@ -66,7 +66,9 @@ class ExodusConnector(phantom.BaseConnector):
                 base_url = f"{base_url}/"
             url = f"{base_url}{endpoint}"
             self.__print(url, True)
-            response = phantom.requests.get(url, headers=headers, verify=False, timeout=30)  # nosemgrep
+            response = phantom.requests.get(
+                url, headers=headers, verify=self.get_config().get("verify_server_cert", True), timeout=30
+            )
             content = json.loads(response.text)
             code = response.status_code
             if code == 200:
@@ -101,7 +103,9 @@ class ExodusConnector(phantom.BaseConnector):
             url = f"{base_url}{endpoint}"
             self.__print(url, True)
             data = json.dumps(dictionary)
-            response = phantom.requests.post(url, headers=headers, data=data, verify=False, timeout=30)  # nosemgrep
+            response = phantom.requests.post(
+                url, headers=headers, data=data, verify=self.get_config().get("verify_server_cert", True), timeout=30
+            )
             content = response.text
             code = response.status_code
             if code == 200:
@@ -129,8 +133,8 @@ class ExodusConnector(phantom.BaseConnector):
         return self._post_rest_data(base_url, endpoint, headers, dictionary)
 
     def _post_asset(self, asset):
-        mysession = phantom.requests.Session()  # nosemgrep
-        mysession.verify = False
+        mysession = phantom.requests.Session()
+        mysession.verify = self.get_config().get("verify_server_cert", True)
         mysession.headers = self._get_target_headers()
         url = f"{self.get_config()['target_base_url']}rest/asset"
         mysession.post(url, json=asset)
@@ -440,7 +444,9 @@ class ExodusConnector(phantom.BaseConnector):
             filepath = f"/tmp/exported_function_{object_id}.tgz"
         response = None
         try:
-            response = phantom.requests.get(file_url, headers=headers, verify=False, timeout=30)  # nosemgrep
+            response = phantom.requests.get(
+                file_url, headers=headers, verify=self.get_config().get("verify_server_cert", True), timeout=30
+            )
         except Exception as e:
             self.__print(e, False)
         try:
@@ -482,7 +488,9 @@ class ExodusConnector(phantom.BaseConnector):
                 body["playbook"] = str(encoded, "utf-8")
             else:
                 body["custom_function"] = str(encoded, "utf-8")
-            resp = phantom.requests.post(post_url, json=body, headers=headers, verify=False, timeout=30)  # nosemgrep
+            resp = phantom.requests.post(
+                post_url, json=body, headers=headers, verify=self.get_config().get("verify_server_cert", True), timeout=30
+            )
             if 199 < resp.status_code < 300:
                 self.__print(f"SUCCESS: {json.loads(resp.text)['message']}", True)
                 f.close()

--- a/exodus_connector.py
+++ b/exodus_connector.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Splunk Inc.
+# Copyright (c) 2025-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -66,9 +66,7 @@ class ExodusConnector(phantom.BaseConnector):
                 base_url = f"{base_url}/"
             url = f"{base_url}{endpoint}"
             self.__print(url, True)
-            response = phantom.requests.get(
-                url, headers=headers, verify=self.get_config().get("verify_server_cert", True), timeout=30
-            )
+            response = phantom.requests.get(url, headers=headers, verify=self.get_config().get("verify_server_cert", True), timeout=30)
             content = json.loads(response.text)
             code = response.status_code
             if code == 200:
@@ -444,9 +442,7 @@ class ExodusConnector(phantom.BaseConnector):
             filepath = f"/tmp/exported_function_{object_id}.tgz"
         response = None
         try:
-            response = phantom.requests.get(
-                file_url, headers=headers, verify=self.get_config().get("verify_server_cert", True), timeout=30
-            )
+            response = phantom.requests.get(file_url, headers=headers, verify=self.get_config().get("verify_server_cert", True), timeout=30)
         except Exception as e:
             self.__print(e, False)
         try:

--- a/readme.html
+++ b/readme.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2025 Splunk Inc.
+ Copyright (c) 2025-2026 Splunk Inc.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Enable TLS certificate verification for source and target SOAR hosts by default.


### PR DESCRIPTION
AI-authored by Codex.

## Summary
- add a secure-by-default TLS verification setting
- apply it to all source and target GET, POST, export, import, and asset migration requests
- refresh connector quality tooling to dev-cicd-tools v2.2.4

## Tracking
- Parent: [PAPP-38168](https://splunk.atlassian.net/browse/PAPP-38168)
- Fixed: [PSAAS-31213](https://splunk.atlassian.net/browse/PSAAS-31213)
- [PSAAS-31319](https://splunk.atlassian.net/browse/PSAAS-31319) is deferred for platform-boundary clarification because its root cause is shared platform-key decryption behavior

## Validation
- `pre-commit run --all-files`

## Tracking

- PAPP: PAPP-38168
- PSAAS: PSAAS-31213
- Written by Codex.